### PR TITLE
refactor: update import paths to use alias '@app' for better readabiility and maintainability

### DIFF
--- a/.github/workflows/pr-reviewer-reminder.yml
+++ b/.github/workflows/pr-reviewer-reminder.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pull-request-reviewer-reminder:
     runs-on: ubuntu-latest
+    container: node:18.19.1
     steps:
       - uses: tommykw/pull-request-reviewer-reminder-action@v2
         with:

--- a/.github/workflows/pr-reviewer-reminder.yml
+++ b/.github/workflows/pr-reviewer-reminder.yml
@@ -1,0 +1,15 @@
+name: 'Pull request reviewer reminder'
+on:
+  schedule:
+    # Check reviews every weekday, 10:00 and 17:00
+    - cron: '0 18,20 * * 1-5'
+
+jobs:
+  pull-request-reviewer-reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tommykw/pull-request-reviewer-reminder-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Required
+          reminder_message: 'One business day has passed since the review started. Give priority to reviews as much as possible.' # Required. Messages to send to reviewers on Github.
+          review_turnaround_hours: 24 # Required. This is the deadline for reviews. If this time is exceeded, a reminder wil be send.

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ArticlesService } from './articles.service';
 import { ArticlesController } from './articles.controller';
-import { PrismaModule } from 'src/prisma/prisma.module';
+import { PrismaModule } from '@app/prisma/prisma.module';
 
 @Module({
   controllers: [ArticlesController],

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '@app/prisma/prisma.service';
 import { CreateArticleDto } from './dto/create-article.dto';
 import { UpdateArticleDto } from './dto/update-article.dto';
 

--- a/src/articles/entities/article.entity.ts
+++ b/src/articles/entities/article.entity.ts
@@ -1,6 +1,6 @@
 import { Article } from '@prisma/client';
 import { ApiProperty } from '@nestjs/swagger';
-import { UserEntity } from 'src/users/entities/user.entity';
+import { UserEntity } from '@app/users/entities/user.entity';
 
 export class ArticleEntity implements Article {
   @ApiProperty()

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,8 +3,8 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule } from '@nestjs/jwt';
-import { PrismaModule } from 'src/prisma/prisma.module';
-import { UsersModule } from 'src/users/users.module';
+import { PrismaModule } from '@app/prisma/prisma.module';
+import { UsersModule } from '@app/users/users.module';
 import { JwtStrategy } from './jwt.strategy';
 
 import { ConfigModule, ConfigService } from '@nestjs/config';

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -2,7 +2,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { UsersService } from 'src/users/users.service';
+import { UsersService } from '@app/users/users.service';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -19,7 +19,7 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import { UserEntity } from './entities/user.entity';
-import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { JwtAuthGuard } from '@app/auth/jwt-auth.guard';
 
 @Controller('users')
 @ApiTags('users')

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
-import { PrismaModule } from 'src/prisma/prisma.module';
+import { PrismaModule } from '@app/prisma/prisma.module';
 
 @Module({
   controllers: [UsersController],

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { PrismaService } from '@app/prisma/prisma.service';
 import * as bcrypt from 'bcrypt';
 
 export const roundsOfHashing = 10;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from '@app/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,13 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "../",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@app/(.*)$": "<rootDir>/src/$1",
+    "^@test/(.*)$": "<rootDir>/test/$1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "paths": {
+      "@app/*": ["src/*"],
+      "@test/*": ["test/*"]
+    },
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION


feat: configure moduleNameMapper in jest-e2e.json to support path aliases
feat: add paths configuration in tsconfig.json to define module aliases

The changes refactor the import statements across multiple files to use the '@app' alias, improving code readability and maintainability. Additionally, the Jest configuration is updated to support these path aliases, ensuring that tests can resolve modules correctly. The TypeScript configuration is also modified to define these aliases, allowing for a more organized project structure.